### PR TITLE
 pre-commit to wrap .po files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/humitos/powrap
+    rev: pre-commit
+    hooks:
+    -   id: powrap

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-docs-theme
 setuptools
 sphinx-intl
 transifex-client
+pre-commit


### PR DESCRIPTION
Los pasos para usar esto son,

```
pre-commit install
```

Luego, cada vez que hagas `git commit` se va a ejecutar automaticamente pre-commit con el hook de powrap y va a hacer fix de los archivos *antes* de comitear.